### PR TITLE
Add instructions for installing the Ruby Bourbon gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ That will copy the Casper theme over to a new folder named NAME-OF-NEW-THEME.
 
 ## Additional setup
 
-Now, make sure you have the grunt-cli tool installed as well as the Bourbon Ruby gem:
+Now, make sure you have the grunt-cli tool installed as well as the [Bourbon](http://bourbon.io/) Ruby gem:
 
 ```
 npm install -g grunt-cli


### PR DESCRIPTION
I noticed that installing Bourbon wasn't mentioned anywhere in the documentation, which confused me at first when trying to get `grunt init` to run.

I'm not sure if there's a way to install a Ruby gem from the Gruntfile, but thought this might be a helpful addition for now!
